### PR TITLE
ci: add action to publish rocks to ghcr

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release Rocks to archives
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Install `just`
+        run: sudo snap install just --classic
+      - name: Install `rockcraft`
+        run: sudo snap install rockcraft --classic
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: 5.21/stable
+      - name: Pack rocks
+        run: just pack
+      - name: Publish rocks to ghcr.io in latest channel
+        if: ${{ github.ref_type }} == "branch"
+        env:
+          DEST_CREDS: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+        run: |
+          versions=(latest "${{ github.sha }}")
+          for version in "${versions[@]}"; do
+            just publish docker://ghcr.io/${{ github.repository }}/ ${version}
+          done

--- a/justfile
+++ b/justfile
@@ -42,9 +42,9 @@ pack *args:
         echo
     done
 
-# Import rocks into the Docker daemon
+# Publish rocks into an OCI archive
 [group("dev")]
-import *args:
+publish base version="latest" *args:
     #!/usr/bin/env bash
     set -eu pipefail
 
@@ -52,11 +52,13 @@ import *args:
     for target in ${targets[@]}; do
         name=$(basename $target)
         rock=$(find {{build_dir}} -maxdepth 1 -type f -iname "${name}_*.rock" | head -1)
-        echo -e "\033[1mImporting rock $name\033[0m"
+        echo -e "\033[1mPublishing rock $name\033[0m"
         {{skopeo}} --insecure-policy copy \
+            ${DEST_CREDS:+--dest-creds $DEST_CREDS} \
             oci-archive:$rock \
-            docker-daemon:${name}:latest
+            {{base}}${name}:{{version}}
     done
+
 
 # Clean project directory and rock builder instances
 [group("dev")]


### PR DESCRIPTION
Adds a CI action that automatically publishes the Slurm Rocks into the Github Containers Registry.