### PR TITLE
docs: update README and fix slurmctld `rockcraft.yaml` linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ just publish  # Publishes all the rocks to your local Docker registry.
 docker run --rm -d --name slurmctld slurmctld:latest  # Runs the slurmctld rock with Docker.
 ```
 
-A more extensive usage example can be seen on the (example)[./example] directory, which sets up all
+A more extensive usage example can be seen on the [example](./example) directory, which sets up all
 the Slurm services into a simple cluster.
 
 [Rockcraft]: https://documentation.ubuntu.com/rockcraft

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Slurm services.
 ## Getting started
 
 To get started with the Slurm rocks, you must have [Rockcraft] and [just] installed for
-packing the rocks, [skopeo] for copying the generated OCI images to your local Docker registry, and
-finally [Docker] for running the images.
+packing the rocks, [skopeo] for copying the generated OCI images to your local Docker registry,
+[yamllint] for checking against coding standards, and finally [Docker] for running the images.
 
 ```bash
 just pack  # Packs all the rocks.
-just import  # Imports all the rocks into your local Docker registry.
+just publish  # Publishes all the rocks to your local Docker registry.
 docker run --rm -d --name slurmctld slurmctld:latest  # Runs the slurmctld rock with Docker.
 ```
 
@@ -21,4 +21,5 @@ the Slurm services into a simple cluster.
 [Rockcraft]: https://documentation.ubuntu.com/rockcraft
 [just]: https://github.com/casey/just
 [skopeo]: https://github.com/containers/skopeo
+[yamllint]: https://github.com/adrienverge/yamllint
 [Docker]: https://www.docker.com

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ packing the rocks, [skopeo] for copying the generated OCI images to your local D
 
 ```bash
 just pack  # Packs all the rocks.
-just publish  # Publishes all the rocks to your local Docker registry.
+just publish docker-daemon: # Publishes all the rocks to your local Docker registry.
 docker run --rm -d --name slurmctld slurmctld:latest  # Runs the slurmctld rock with Docker.
 ```
 

--- a/rocks/slurmctld/rockcraft.yaml
+++ b/rocks/slurmctld/rockcraft.yaml
@@ -33,7 +33,9 @@ services:
   slurmctld:
     override: replace
     startup: enabled
-    command: /usr/sbin/slurmctld -D [ -f /etc/slurm/slurm.conf -L /var/log/slurm/slurmctld.log ]
+    command: >-
+      /usr/sbin/slurmctld -D
+      [ -f /etc/slurm/slurm.conf -L /var/log/slurm/slurmctld.log ]
     on-failure: restart
     backoff-delay: 10s
 


### PR DESCRIPTION
This PR updates README.md to:
* Include yamllint as a prerequisite
* Change `just import` to `just publish` (this action was renamed in https://github.com/canonical/slurm-rocks/pull/2)
* Fix the link to the `examples` directory

It also splits the `command` line in `rocks/slurmctld/rockcraft.yaml` to be under 80 characters so `just lint` passes.