### PR TITLE
ci: add testing pipeline for slinky

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,62 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: slurm rocks tests
+on:
+  workflow_call:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-test:
+    name: Integration tests (LXD)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Remove unnecessary files
+        run: |
+          # Remove Java SDKs
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove Haskell toolchain
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove unnecessary runner tools
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install `just`
+        run: sudo snap install just --classic
+      - name: Install `rockcraft`
+        run: sudo snap install rockcraft --classic
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: 5.21/stable
+      - name: Pack rocks
+        run: just pack
+      - name: Run integration tests
+        run: just integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ just pack
 
 # Publish all rocks to the docker-daemon registry
 just publish docker-daemon: latest
+
+# Run integration tests on the rocks using LXD
+just integration
 ```
 
 Run `just help` to view the full list of available recipes.
@@ -18,9 +21,12 @@ Run `just help` to view the full list of available recipes.
 
 ## Testing against Slinky
 
-To test the Rocks while hacking, you will first require deploying a local container
-registry. If you have [Docker](https://www.docker.com/) installed, you can
-deploy a local registry by running
+The [`vm-setup.yaml`](./tests/vm-setup.yaml) and [`test-slinky.sh`](./tests/test-slinky.sh)
+files show how to use [Canonical k8s][ck8s] to deploy a testing Slurm cluster with
+Slinky.
+
+If you plan on using an alternative local k8s implementation, and you have [Docker]
+installed, you can deploy a local registry by running
 
 ```shell
 docker run -d -p 5000:5000 --restart=always --name registry registry:2
@@ -35,3 +41,6 @@ SKOPEO_FLAGS='--dest-tls-verify=false' just publish docker://localhost:5000/ lat
 Then, you can follow the [Slinky guide][./SLINKY.md], replacing any reference to the
 Github Container Registry with the local container registry;
 `ghcr.io/canonical/slurm-rocks/slurmctld` becomes `localhost:5000/slurmctld`.
+
+[ck8s]: https://documentation.ubuntu.com/canonical-kubernetes/release-1.32
+[Docker]: https://www.docker.com/)

--- a/SLINKY.md
+++ b/SLINKY.md
@@ -1,23 +1,42 @@
 # Using the Slurm rocks with Slinky
 
-First, install Microk8s
+First, install Canonical K8s
 
 ```shell
-sudo snap install microk8s --channel 1.34-strict/stable
-sudo usermod -a -G microk8s $USER
-mkdir -p ~/.kube
-chmod 0700 ~/.kube
-su - $USER
-microk8s status --wait-ready
-alias kubectl='microk8s kubectl'
+sudo snap install k8s --classic --channel 1.32-classic/stable
+alias kubectl='sudo k8s kubectl'
 ```
 
-Next, enable some required plugins
+Setup the required bootstrap configuration
 
 ```shell
-sudo microk8s enable hostpath-storage
-sudo microk8s enable cert-manager
-sudo microk8s enable observability
+cat <<EOF > bootstrap.yaml
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  gateway:
+    enabled: true
+  ingress:
+    enabled: true
+  local-storage:
+    enabled: true
+EOF
+```
+
+Then, bootstrap and wait until the k8s cluster finishes its setup
+
+```shell
+sudo k8s bootstrap --file bootstrap.yaml
+sudo k8s status --wait-ready --timeout 10m
+```
+
+You will also need to setup `.kube/config` such that helm can fetch the k8s configuration
+```shell
+sudo mkdir -p /root/.kube
+sudo chmod 0700 /root/.kube
+kubectl config view --raw > /root/.kube/config
 ```
 
 Install Helm
@@ -26,9 +45,25 @@ Install Helm
 sudo snap install helm --classic
 ```
 
-Then, install the required helm repo
+Then, install the required helm repos
 ```shell
 helm repo add mariadb-operator https://helm.mariadb.com/mariadb-operator
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+```
+
+Deploy the certificate manager and the observability stacks
+```shell
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true
+helm install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace prometheus \
+  --create-namespace \
+  --set installCRDs=true
 ```
 
 Next, install the required custom resource definitions.

--- a/justfile
+++ b/justfile
@@ -16,9 +16,12 @@ set unstable := true
 rockcraft := require("rockcraft")
 skopeo := which("rockcraft.skopeo") || require("skopeo")
 yamllint := require("yamllint")
+lxc := require("lxc")
+yq := require("yq")
 
 build_dir := justfile_dir() / "_build"
 rocks_dir := justfile_dir() / "rocks"
+tests_dir := justfile_dir() / "tests"
 default_targets := shell("ls -d -- $1/*", rocks_dir)
 
 [private]
@@ -80,6 +83,71 @@ clean:
        {{rockcraft}} -v clean
        echo
     done
+
+[doc("""
+  Run integration tests using LXD
+
+  Setting the `SLURM_ROCKS_PRESERVE` environment will skip deleting the
+  machine after a test success. Failing a test will always preserve the machine
+  it was run on.
+""")]
+[group("dev")]
+integration:
+    #!/usr/bin/env bash
+    set -eu pipefail
+
+    run_test() {
+        test_file=$1
+        test_name=$(basename -s .sh $test_file)
+        export MACHINE="slurm-rocks-$test_name-{{choose('6', HEX)}}"
+
+        {{lxc}} launch ubuntu:24.04 $MACHINE \
+            -c limits.cpu=4 \
+            -c limits.memory=8GiB \
+            --device root,size=50GiB \
+            --vm \
+            --config=user.user-data="$(cat {{tests_dir / "vm-setup.yaml"}})"
+
+        processes=-1
+        while : ; do
+            processes=$({{lxc}} info $MACHINE | {{yq}} .Resources.Processes)
+            # The number of processes will be -1 if the LXD agent has not started.
+            [[ $processes -eq -1 ]] || break
+            sleep 2
+        done
+
+        echo -e "\033[1mWaiting for cloud-init\033[0m"
+        {{lxc}} exec $MACHINE -- cloud-init status --wait --long
+
+        targets=({{default_targets}})
+        for target in ${targets[@]}; do
+            name=$(basename $target)
+            rock=$(find {{build_dir}} -maxdepth 1 -type f -iname "${name}_*.rock" | head -1)
+            echo -e "\033[1mPushing rock $name\033[0m"
+            {{lxc}} file push $rock $MACHINE/root/${name}.rock
+
+            {{lxc}} exec $MACHINE -- rockcraft.skopeo copy \
+                --insecure-policy \
+                --dest-tls-verify=false \
+                oci-archive:/root/${name}.rock \
+                docker://localhost:30100/${name}:latest
+        done
+
+        echo -e "\033[1mRunning \`${test_name}\`\033[0m"
+        $test_file
+
+        if [ -v SLURM_ROCKS_PRESERVE ]; then
+            echo -e "\033[1mSkipped Cleaning up machine \`${MACHINE}\`\033[0m"
+        else
+            echo -e "\033[1mCleaning up machine \`${MACHINE}\`\033[0m"
+            {{lxc}} delete $MACHINE --force
+        fi
+    }
+
+    export -f run_test
+
+    find {{tests_dir}} -maxdepth 1 -type f -iname "test*.sh" \
+        | xargs -0L1 bash -c 'set -eu pipefail; run_test "$0"'
 
 # Check code against coding style standards
 [group("lint")]

--- a/tests/test-slinky.sh
+++ b/tests/test-slinky.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -eux pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+lxc file push $SCRIPT_DIR/values-mariadb.yaml $MACHINE/root/values-mariadb.yaml
+
+lxc exec $MACHINE -- bash <<EOF
+set -eux pipefail
+
+echo "Installing helm requirements..."
+
+helm repo add mariadb-operator https://helm.mariadb.com/mariadb-operator
+helm repo update
+
+helm install mariadb-operator-crds mariadb-operator/mariadb-operator-crds
+helm install mariadb-operator mariadb-operator/mariadb-operator \
+  -n=mariadb \
+  --create-namespace
+k8s kubectl wait pod --all --for=condition=Ready -n=mariadb --timeout=10m
+
+helm install slurm-operator-crds oci://ghcr.io/slinkyproject/charts/slurm-operator-crds
+helm install slurm-operator oci://ghcr.io/slinkyproject/charts/slurm-operator \
+  -n=slinky \
+  --create-namespace
+k8s kubectl wait pod --all --for=condition=Ready -n=slinky --timeout=10m
+
+k8s kubectl create ns slurm
+
+echo "Deploying mariadb..."
+k8s kubectl create secret generic mariadb-root --from-literal=password=password -n=slurm
+k8s kubectl create secret generic mariadb-password --from-literal=password=password -n=slurm
+helm install mariadb mariadb-operator/mariadb-cluster -n=slurm -f values-mariadb.yaml
+k8s kubectl wait pod --all --for=condition=Ready -n=slurm --timeout=10m
+
+echo "Deploying slurm..."
+helm install slurm oci://ghcr.io/slinkyproject/charts/slurm \
+  -n=slurm \
+  --set imagePullPolicy=always \
+  --set controller.slurmctld.image.repository=localhost:30100/slurmctld \
+  --set controller.slurmctld.image.tag=latest \
+  --set controller.reconfigure.image.repository=localhost:30100/sackd \
+  --set controller.reconfigure.image.tag=latest \
+  --set restapi.slurmrestd.image.repository=localhost:30100/slurmrestd \
+  --set restapi.slurmrestd.image.tag=latest \
+  --set accounting.enabled=true \
+  --set accounting.slurmdbd.image.repository=localhost:30100/slurmdbd \
+  --set accounting.slurmdbd.image.tag=latest \
+  --set accounting.storageConfig.host=mariadb-mariadb-cluster \
+  --set accounting.storageConfig.database=slurmdb \
+  --set nodesets.slinky.slurmd.image.repository=localhost:30100/slurmd \
+  --set nodesets.slinky.slurmd.image.tag=latest \
+  --set loginsets.slinky.enabled=true \
+  --set loginsets.slinky.login.image.repository=localhost:30100/login \
+  --set loginsets.slinky.login.image.tag=latest \
+  --set loginsets.slinky.service.type=NodePort \
+  --set loginsets.slinky.service.port=22 \
+  --set loginsets.slinky.service.protocol=TCP \
+  --set-file "loginsets.slinky.rootSshAuthorizedKeys=\${HOME}/.ssh/id_ed25519.pub"
+
+k8s kubectl wait pod --all --for=condition=Ready -n=slurm --timeout=10m
+
+port="\$(k8s kubectl -n=slurm get svc slurm-login-slinky -o jsonpath='{.spec.ports[0].nodePort}')"
+
+ssh localhost \
+    -i \${HOME}/.ssh/id_ed25519 \
+    -p \$port \
+    -o StrictHostKeyChecking=no \
+    -- bash <<EOS
+
+set -eux pipefail
+
+scontrol ping
+srun hostname
+sacctmgr list stats
+
+EOS
+
+EOF

--- a/tests/values-mariadb.yaml
+++ b/tests/values-mariadb.yaml
@@ -1,0 +1,49 @@
+mariadb:
+  rootPasswordSecretKeyRef:
+    name: mariadb-root
+    key: password
+  storage:
+    size: 10Gi
+  replicas: 1
+  galera:
+    enabled: false
+  myCnf: |
+    [mariadb]
+    bind-address=*
+    default_storage_engine=InnoDB
+    binlog_format=row
+    innodb_autoinc_lock_mode=2
+    innodb_buffer_pool_size=4096M
+    innodb_lock_wait_timeout=900
+    innodb_log_file_size=1024M
+    max_allowed_packet=256M
+  metrics:
+    enabled: true
+databases:
+  - name: slurmdb
+    characterSet: utf8
+    collate: utf8_general_ci
+    cleanupPolicy: Delete
+    requeueInterval: 10h
+    retryInterval: 30s
+users:
+  - name: slurm
+    passwordSecretKeyRef:
+      name: mariadb-password
+      key: password
+    host: "%"
+    cleanupPolicy: Delete
+    requeueInterval: 10h
+    retryInterval: 30s
+grants:
+  - name: slurmdb
+    privileges:
+      - "ALL PRIVILEGES"
+    database: "slurmdb"
+    table: "*"
+    username: slurm
+    grantOption: true
+    host: "%"
+    cleanupPolicy: Delete
+    requeueInterval: 10h
+    retryInterval: 30s

--- a/tests/vm-setup.yaml
+++ b/tests/vm-setup.yaml
@@ -1,0 +1,130 @@
+#cloud-config
+
+# prerequisites
+snap:
+  commands:
+    00: [install, k8s, --classic]
+    01: [install, helm, --classic]
+    02: [install, rockcraft, --classic]
+
+write_files:
+  # Canonical k8s bootstrap setup
+  - path: /run/ck8s/bootstrap.yaml
+    defer: false
+    content: |
+      cluster-config:
+        network:
+          enabled: true
+        dns:
+          enabled: true
+        gateway:
+          enabled: true
+        ingress:
+          enabled: true
+        local-storage:
+          enabled: true
+  # Container registry deployment plan
+  - path: /run/ck8s/registry.yaml
+    defer: false
+    content: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: kube-registry
+      ---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app: registry
+        name: registry
+        namespace: kube-registry
+      spec:
+        ports:
+        - nodePort: 30100
+          port: 5000
+          protocol: TCP
+          targetPort: 5000
+        selector:
+          app: registry
+        type: NodePort
+      ---
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: registry-pvc
+        namespace: kube-registry
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      ---
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        labels:
+          app: registry
+        name: registry
+        namespace: kube-registry
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: registry
+        template:
+          metadata:
+            labels:
+              app: registry
+          spec:
+            containers:
+            - image: registry:2
+              imagePullPolicy: IfNotPresent
+              name: registry
+              volumeMounts:
+              - mountPath: /var/lib/registry
+                name: registry-vol
+            volumes:
+            - name: registry-vol
+              persistentVolumeClaim:
+                claimName: registry-pvc
+
+runcmd:
+  - |
+    #!/bin/bash
+
+    set -eux pipefail
+
+    export HOME=/root
+
+    # Generate SSH keys to test the login nodes
+    ssh-keygen -t ed25519 -f $HOME/.ssh/id_ed25519 -N ""
+
+    k8s bootstrap --file /run/ck8s/bootstrap.yaml --timeout 5m
+    k8s status --wait-ready --timeout 20m
+    k8s kubectl wait pod --all --for=condition=Ready -n=kube-system --timeout=20m
+
+    # Need to setup .kube/config for helm
+    mkdir -p /root/.kube
+    k8s kubectl config view --raw > /root/.kube/config
+
+    # Install required helm charts for mariadb and slurm
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+    helm repo add jetstack https://charts.jetstack.io
+    helm repo update
+    helm install cert-manager jetstack/cert-manager \
+      --namespace cert-manager \
+      --create-namespace \
+      --set crds.enabled=true
+    helm install prometheus prometheus-community/kube-prometheus-stack \
+      --namespace prometheus \
+      --create-namespace \
+      --set installCRDs=true
+    k8s kubectl wait pod --all --for=condition=Ready -n=cert-manager --timeout=10m
+    k8s kubectl wait pod --all --for=condition=Ready -n=prometheus --timeout=10m
+
+    # Create container registry
+    k8s kubectl apply -f /run/ck8s/registry.yaml
+    k8s kubectl wait pod --all --for=condition=Ready -n=kube-registry --timeout=10m


### PR DESCRIPTION
This adds a new CI pipeline for the rocks that tests against the latest version of Slinky, and checks that everything deploys correctly.

The new `just` job can also be used to test locally, which is really convenient for development. 